### PR TITLE
AGP-16: Extend AGP Vote Duration

### DIFF
--- a/AGPs/AGP-16.md
+++ b/AGPs/AGP-16.md
@@ -1,5 +1,5 @@
 ---
-AGP: N/A
+AGP: 16
 Title: Extend AGP Vote Duration
 Author: lkngtn
 Status: Stage V


### PR DESCRIPTION
This proposal is strictly to extend the duration for AGP votes from 48 hours to 168 hours. 