### PR TITLE
Set AGP editors as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @aragon/agp-editors


### PR DESCRIPTION
I am also setting branch protection for master in this repo:
<img width="738" alt="2019-01-10 at 9 49 39 am" src="https://user-images.githubusercontent.com/447328/50956874-1d08c800-14bd-11e9-9eba-5dc413e54ed6.png">
