### PR TITLE
Create AGP-AGP-Authorship-Standards.md

### DIFF
--- a/AGPs/AGP-AGP-Authorship-Standards.md
+++ b/AGPs/AGP-AGP-Authorship-Standards.md
@@ -1,0 +1,35 @@
+
+---
+AGP: N/A
+Title: AGP Authorship Standards
+Author: burrrata (@burrrata)
+Status: Stage III
+Track: Meta
+Created: 2019-10-02
+---
+
+# AGP-X: AGP Authorship Standards
+
+## File changed (AGP-0 or AGP-1)
+
+AGP-1
+
+## Link to proposed change
+
+TBD
+
+## Motivation for making this change
+
+Collaboration is not a zero-sum game. This is what makes being a member of the Aragon community so attractive, rewarding, and enriching. Sometimes this process can be contentious. Many people contribute ideas to discussions on the [Aragon Forum](https://forum.aragon.org/), but only 1 or 2 people end up formalizing those ideas into an AGP. Sometimes someone will start a discussion or GitHub Issue around an AGP, but not submit a formal proposal. There is currently no formal protocol to address these edge cases.
+
+To address this we need to make some changes:
+- If an AGP discussion is open on the Aragon Forum or the Aragon AGP GitHub repo, the person who started that discussion has the first claim on submission of a formal AGP around that idea. This claim on the AGP is only valid from the time the issue/thread is opened until the next ANV.
+- If it seems like discussions around an open thread/issue have been abandoned, and the author still has a claim on AGP submission, you need to get permission from that author before submitting an AGP yourself for the idea.
+- A section will be added to all AGP templates for “Contributions and Prior Work.” This will allow authors to add attribution info to AGPs in a clear and unambiguous manner. If anyone feels that they are not given due credit where credit is due they can request this change in the AGP review period. This request must be accompanied by proof of contribution. It is up to the AGP reviewers to determine if this claim is valid, and if so, add the contributor to the "Contributions and Prior Work" section of the AGP.
+
+## License
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+## Contributions and Prior Work
+
+This AGP is directly sourced from the [Authorship Standards for APGs](https://forum.aragon.org/t/authorship-standards-for-agps/1037) thread which arose due to the controversy and confusion surrounding the [AGP discussion: Community Review Period](https://forum.aragon.org/t/agp-discussion-community-review-period/986) thread. Thank you to Aaron Foster, Brett Sun, John Light, and Yalda Mousavinia for your contributions. 

--- a/AGPs/AGP-AGP-Authorship-Standards.md
+++ b/AGPs/AGP-AGP-Authorship-Standards.md
@@ -16,7 +16,7 @@ AGP-1
 
 ## Link to proposed change
 
-TBD
+https://github.com/aragon/AGPs/pull/95
 
 ## Motivation for making this change
 


### PR DESCRIPTION
### Meta-tack AGP

Provides instructions on how to give due credit where credit is due in the context AGPs. 

Changes to AGP-1 can be found here: https://github.com/aragon/AGPs/pull/95