### PR TITLE
AGP Authorship Rewards Program

### DIFF
--- a/AGPs/AGP-Authorship-Rewards-Program.md
+++ b/AGPs/AGP-Authorship-Rewards-Program.md
@@ -23,19 +23,19 @@ AGP authors and contributors
 
 ## Purpose of the transfer
 
-Aragon is a decentralized governance platform. AGPs are the foundation of the governance process. Engaging in governance is hard. It takes lots of time, emotional energy, and time. There is currently no motivation to engage in AGP discussions or author AGPs other than altruism or personal interest. This greatly reduces the amount of proposals that are put forward. 
+Aragon is a decentralized governance platform. AGPs are the foundation of the governance process. Engaging in governance is hard. It takes lots of time, emotional energy, and time. There is currently no motivation to engage in AGP discussions or author AGPs other than altruism or personal interest. This greatly reduces the amount of proposals that are put forward.
 
-To address this I propose that we reward AGP authors. They are doing the Aragon community a service by engaging in discussions, packing ideas into AGPs, receiving community feedback, modifying AGPs, and ultimately realizing of the Aragon community's ideas. Being how AGPs are one of the most important aspects of the Aragon community, 1000 ANT seems like a healthy amount to get more people's attention focused on AGPs, both in authorship and dilligence. 
+To address this we need to reward AGP authors. They are doing the Aragon community a service by engaging in discussions, packing ideas into AGPs, receiving community feedback, modifying AGPs, and ultimately realizing the Aragon community's ideas in a tangible manner. AGPs are one of the most important aspects of the Aragon community so 1000 ANT seems like a healthy amount to get more people's attention focused on AGPs, both in authorship and diligence.
 
-To make this process concrete, AGP authorship rewards could be as follows:
+To make this process concrete, AGP authorship rewards would be as follows:
 - 300 ANT to the author of an AGP that is approved by the AA for an upcoming ANV
 - 200 ANT to contributors of an AGP that is approved by the AA for an upcoming ANV
 - 300 ANT to the author of an AGP that is approved by ANT voters
 - 200 ANT to contributors of an AGP that is approved by ANT voters
 
-This will require all AGP authors to list contributors to the AGP. To keep things simple contributor rewards will be split equally between all contributors. While this does not account for the fact that some contributors will have done more work than others, it's a step forward from the current process. If a community member has contributed a lot they can be listed as a co-author and the authorship reward can be split between co-authors. This will encourage collaboration by rewarding and recognizing community members who contribute to AGP conversations.
+This will require all AGP authors to list contributors to the AGP. To keep things simple contributor rewards will be split equally between all contributors. While this does not account for the fact that some contributors will have done more work than others, it's a major step forward from the current process. If a community member has contributed a lot they can be listed as a co-author and the authorship reward can be split between co-authors. This will encourage collaboration by rewarding and recognizing community members who contribute to AGP conversations.
 
-In order to receive authorship or contributor rewards authors and/or contributors must add an Ethereum address to the AGP where they wish to receive rewards. 
+In order to receive authorship or contributor rewards authors and/or contributors must add an Ethereum address to the AGP where they wish to receive rewards.
 
 ## Recipient information
 

--- a/AGPs/AGP-Authorship-Rewards-Program.md
+++ b/AGPs/AGP-Authorship-Rewards-Program.md
@@ -1,0 +1,45 @@
+---
+AGP: N/A
+Title: AGP Authorship Rewards Program
+Author: burrrata (@burrrata)
+Status: Stage III
+Track: Finance
+Created: 2019-10-02
+---
+
+# AGP-X: AGP Authorship Rewards Program
+
+## Address of the transfer recipient
+
+AGP authors and contributors
+
+## Amount of the transfer
+
+1000 ANT
+
+## Number and frequency of transfers if recurring (enter “1” if only one payment will be made)
+
+1
+
+## Purpose of the transfer
+
+Aragon is a decentralized governance platform. AGPs are the foundation of the governance process. Engaging in governance is hard. It takes lots of time, emotional energy, and time. There is currently no motivation to engage in AGP discussions or author AGPs other than altruism or personal interest. This greatly reduces the amount of proposals that are put forward. 
+
+To address this I propose that we reward AGP authors. They are doing the Aragon community a service by engaging in discussions, packing ideas into AGPs, receiving community feedback, modifying AGPs, and ultimately realizing of the Aragon community's ideas. Being how AGPs are one of the most important aspects of the Aragon community, 1000 ANT seems like a healthy amount to get more people's attention focused on AGPs, both in authorship and dilligence. 
+
+To make this process concrete, AGP authorship rewards could be as follows:
+- 300 ANT to the author of an AGP that is approved by the AA for an upcoming ANV
+- 200 ANT to contributors of an AGP that is approved by the AA for an upcoming ANV
+- 300 ANT to the author of an AGP that is approved by ANT voters
+- 200 ANT to contributors of an AGP that is approved by ANT voters
+
+This will require all AGP authors to list contributors to the AGP. To keep things simple contributor rewards will be split equally between all contributors. While this does not account for the fact that some contributors will have done more work than others, it's a step forward from the current process. If a community member has contributed a lot they can be listed as a co-author and the authorship reward can be split between co-authors. This will encourage collaboration by rewarding and recognizing community members who contribute to AGP conversations.
+
+In order to receive authorship or contributor rewards authors and/or contributors must add an Ethereum address to the AGP where they wish to receive rewards. 
+
+## Recipient information
+
+Future AGP authors and contributors.
+
+## License
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Proposal to reward AGP authors and contributors in order to incentivize more attention and effort towards Aragon governance.