### PR TITLE
Create AGP: Comprehensive Aragon Security Review Program

### DIFF
--- a/AGPs/AGP-Comprehensive-Aragon-Security-Review-Program.md
+++ b/AGPs/AGP-Comprehensive-Aragon-Security-Review-Program.md
@@ -1,0 +1,30 @@
+---
+AGP: N/A
+Title: Comprehensive Aragon Security Review Program
+Author: burrrata (@burrrata)
+Status: Stage III
+Track: Association
+Created: 2019-10-02
+---
+
+# AGP-X: Comprehensive Aragon Security Review Program
+
+## Description of desired Association policy change
+
+This proposal is to expand the [Aragon Security Review](https://github.com/aragon/security-review/) program to include all Nest and Flock projects. This will allow developers to focus on building thier applications. It will also allow the Aragon Association to build relationships with auditors, reducing time and money spent on security audits overall. This is essential for Aragon to be able to provide professional and trusted solutions for organizations on a global scale.
+
+Aragon app developers (Nest or Flock) would be required to submit documentation along with a frozen codebase to the AA. At that point the AA would reveiw and, if satisfactory, hand off the project to a security partnet. The security partner would then review, present findings, and provie suggestions for improvement. The Aragon app developers would then need to incorporate all major and critical suggestions provided by the security partner before receiving their ANT bonus. 
+
+## Motivation for changing this Association policy
+
+Aragon is now shipping more apps through [Autark](https://www.autark.xyz/), [Aragon Black](https://aragon.black/), and the [Nest program](https://github.com/aragon/nest/). These apps are amazing and could unlock tons of value, but only if people use them…
+
+People are wary of DAOs because of [“the DAO” hack](http://hackingdistributed.com/2016/05/27/dao-call-for-moratorium/). For people to trust (and thus use) Aragon we need to go above and beyond to prove that the Aragon platform, and all major releases of Aragon apps, are secure. This is easier said than done.
+- Security audits are not perfect. Even with an audit all you know is what was reported. They might have missed something.
+- Security audits are highly technical and the process is opaque to people who are not involved in the Ethereum security commuinty.
+- Security audits are expensive. Having strategic and financial help to navigate that negotiation is extremely important!
+
+Aragon is trying to attract talent and users. Having the worlds easiest to build on _and_ most secure platform is a huge selling point. If developers see that they will have help shipping professional and production ready applications they are more likely to choose to build on Aragon vs other platforms. If users trust that all major Aragon apps are secure, they’re more likely to use them. To do this we need a multi layered approach to security. This can include audits for all major projects (Nest and Flock) as well as a comprehensive Bug Bounty program that covers all major apps. This is a small price to pay to establish credibility and trust in the Aragon platform and developer ecosystem.
+
+## License
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Note: this PR is intended to fix a technical error in PR #108 

Original comment by @burrrata:

> Expands the scope of the Aragon Security Review Program to include all Nest and Flock projects.
> 
> Was part of #94. As requested is now a separate PR.