### PR TITLE
Create AGP: Comprehensive Aragon Bug Bounty Program

### DIFF
--- a/AGPs/AGP-Comprehensive-Aragon-Bug-Bounty-Program.md
+++ b/AGPs/AGP-Comprehensive-Aragon-Bug-Bounty-Program.md
@@ -1,0 +1,56 @@
+---
+AGP: N/A
+Title: Comprehensive Aragon Bug Bounty Program
+Author: burrrata (@burrrata)
+Status: Stage III
+Track: Association
+Created: 2019-10-02
+---
+
+# AGP-X: Comprehensive Aragon Bug Bounty Program
+
+## Description of desired Association policy change
+
+This proposal is to create a comprehensive [Bug Bounty Program](https://wiki.aragon.org/dev/bug_bounty/) for all funded Aragon applications and tooling. 
+
+### Bug Bounty Scope
+
+The scope of the [Aragon Association Bug Bounty Program](https://wiki.aragon.org/dev/bug_bounty/) will be expanded to make all Nest grantees and Flock team applications eligible. Applications will only be accepted into the bug bounty program if they have undergone a security audit, incorporated all major and critical security audit recommendations, and shipped to mainnet. 
+
+### Bug Bounty Levels
+
+The [Aragon Association Bug Bounty Program](https://wiki.aragon.org/dev/bug_bounty/) would increase the Bug Bounty rewards. 
+
+Currently the Aragon Association Bug Bounty program covers:
+- Critical (CVSS 9.0 - 10.0): $5,000 - $50,000
+- Major (CVSS 7.0 - 8.9): $2,500 - $5,000
+- Medium (CVSS 4.0 - 6.0): $1,000 - $2,500
+- Low (CVSS 1.0 - 3.9): $500 - $1,000
+
+If we are spending millions of dollars on Flock teams and hundreds of thousands of dollars on Nest projects, we can at least spend a little more on our bug bounties. Aragon DAOs currently hold hundreds of thousands of dollars in thier vaults, and soon that will be millions. Paying out $10,000 for a critical vulnerability is simply insufficient. 
+
+The Aragon Association Bug Bounty program will be upgraded to the following levels:
+- Critical (CVSS 9.0 - 10.0): $50,000 - $150,000
+- Major (CVSS 7.0 - 8.9): $25,000 - $50,000
+- Medium (CVSS 4.0 - 6.0): $10,000 - $25,000
+- Low (CVSS 1.0 - 3.9): $5000 - $10,000
+
+Considering that these bounties will only be paid out in the case that there is a problem, it's a small price to pay to minimize mission critical errors and build trust in Aragon as a platform.
+
+## Motivation for changing this Association policy
+
+Aragon is now shipping more apps through [Autark](https://www.autark.xyz/), [Aragon Black](https://aragon.black/), and the [Nest program](https://github.com/aragon/nest/). These apps are amazing and could unlock tons of value, but only if people use them…
+
+People are wary of DAOs because of [“the DAO” hack](http://hackingdistributed.com/2016/05/27/dao-call-for-moratorium/). For people to trust (and thus use) Aragon we need to go above and beyond to prove that the Aragon platform, and all major releases of Aragon apps, are secure. This is easier said than done.
+- Security audits are not perfect. Even with an audit all you know is what was reported. They might have missed something.
+- Security audits are highly technical and the process is opaque to people who are not involved in the Ethereum security commuinty.
+- Security audits are expensive. Having strategic and financial help to navigate that negotiation is extremely important!
+
+Aragon is trying to attract talent and users. Having the worlds easiest to build on _and_ most secure platform is a huge selling point. If developers see that they will have help shipping professional and production ready applications they are more likely to choose to build on Aragon vs other platforms. If users trust that all major Aragon apps are secure, they’re more likely to use them. To do this we need a multi layered approach to security. This can include audits for all major projects (Nest and Flock) as well as a comprehensive Bug Bounty program that covers all major apps. This is a small price to pay to establish credibility and trust in the Aragon platform and developer ecosystem.
+
+## License
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+<hr>
+
+> This proposal is inspired by @stellarmagnet's post on [Upgrading the Bug Bounty program](https://forum.aragon.org/t/upgrading-the-bug-bounty-program-potential-agp/562). Ideas are easy, but shipping a polished, secure, and usable app to production is hard. Thank you for bringing this up and starting the conversation! :) 


### PR DESCRIPTION
Note: this PR is intended to fix a technical error in PR https://github.com/aragon/AGPs/pull/107

Original comment by @burrrata: 
> Expands the scope of the Aragon Bug Bounty program to include all Nest and Flock projects that have undergone a security review and fixed all major critical vulnerabilities.
> 
> Was part of #94. As requested is now a separate PR.