### PR TITLE
AGP-119: Authorship Rewards Program

### DIFF
--- a/AGPs/AGP-119.md
+++ b/AGPs/AGP-119.md
@@ -1,13 +1,13 @@
 ---
-AGP: N/A
-Title: AGP Authorship Rewards Program
+AGP: 119
+Title: Authorship Rewards Program
 Author: burrrata (@burrrata)
-Status: Stage IV
+Status: Stage V
 Track: Association
 Created: 2019-10-02
 ---
 
-# AGP-X: AGP Authorship Rewards Program
+# AGP-119: Authorship Rewards Program
 
 ## Description of desired Association policy change
 

--- a/AGPs/AGP-Authorship-Rewards-Program.md
+++ b/AGPs/AGP-Authorship-Rewards-Program.md
@@ -1,0 +1,55 @@
+---
+AGP: N/A
+Title: AGP Authorship Rewards Program
+Author: burrrata (@burrrata)
+Status: Stage IV
+Track: Finance
+Created: 2019-10-02
+---
+
+# AGP-X: AGP Authorship Rewards Program
+
+## Address of the transfer recipient
+AGP authors and contributors will list addresses on future AGPs.
+
+## Amount of the transfer
+300 ANT to the author of an AGP that is approved by the AA for an upcoming ANV.
+
+200 ANT to any listed contributors of an AGP that is approved by the AA for an upcoming ANV.
+
+300 ANT to the author of an AGP that is approved by ANT voters.
+
+200 ANT to any listed contributors of an AGP that is approved by ANT voters.
+
+## Number and frequency of transfers if recurring (enter “1” if only one payment will be made)
+1.
+
+## Purpose of the transfer
+Aragon is a decentralized governance platform. AGPs are the foundation of the governance process. Engaging in governance is hard. It takes lots of time, emotional energy, and time. There is currently no motivation to engage in AGP discussions or author AGPs other than altruism or personal interest. This greatly reduces the time and effort spent on AGPs.
+
+To address this we need to reward AGP authors. They are doing the Aragon community a service by engaging in discussions, packing ideas into AGPs, receiving community feedback, modifying AGPs, and pushing them through the various stages of the ANV process. AGPs are one of the most important aspects of the Aragon community.
+
+The following rewards seem like a healthy incentive to get more people's attention focused on AGPs, both in authorship and diligence:
+- 300 ANT to the author of an AGP that is approved by the AA for an upcoming ANV
+- 200 ANT to contributors of an AGP that is approved by the AA for an upcoming ANV
+- 300 ANT to the author of an AGP that is approved by ANT voters
+- 200 ANT to contributors of an AGP that is approved by ANT voters
+
+ Passing the community review and Aragon Association review periods disqualifies any completely spammy proposals. If a proposal makes it through both review periods it could be assumed that it is adding some value to the community. Passing in an Aragon Network Vote shows that ANT holders appreciate the proposal and want the value it creates. AGP authors and contributors do a lot of work to provide this value and they should be rewarded accordingly.
+
+If AGP authors do not list contributors in an AGP, then the contributor rewards will simply not be paid out. The AGP author will not be paid more.
+
+If an AGP author lists contributors, rewards will be split equally between all contributors equally. While this does not account for the fact that some contributors will have done more work than others, it keeps things simple and is a major step forward from the current situation.
+
+If a community member has contributed a lot they can be listed as a co-author and the authorship reward can be split between co-authors. Overall, this AGP aims to encourage collaboration by rewarding and recognizing community members who contribute to AGP conversations.
+
+In order to receive authorship or contributor rewards authors and/or contributors must add an Ethereum address to the AGP where they wish to receive authorship or contributor rewards.
+
+The Aragon Association will pay out AGP authorship and contributor rewards at the end of every ANV cycle after ANT votes have been finalized and announced.
+
+## Recipient information
+Future AGP authors and contributors.
+
+## License
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+

--- a/AGPs/AGP-Authorship-Rewards-Program.md
+++ b/AGPs/AGP-Authorship-Rewards-Program.md
@@ -3,53 +3,40 @@ AGP: N/A
 Title: AGP Authorship Rewards Program
 Author: burrrata (@burrrata)
 Status: Stage IV
-Track: Finance
+Track: Association
 Created: 2019-10-02
 ---
 
 # AGP-X: AGP Authorship Rewards Program
 
-## Address of the transfer recipient
-AGP authors and contributors will list addresses on future AGPs.
+## Description of desired Association policy change
 
-## Amount of the transfer
-300 ANT to the author of an AGP that is approved by the AA for an upcoming ANV.
+The Aragon Association will reward AGP authors and contributors with ANT at the end of every ANV cycle after ANT votes have been finalized and announced. The ANT rewards will be:
+- 300 ANT to be split between any listed authors of an AGP that is approved by the AA for an upcoming ANV.
+- 200 ANT to be split between any listed contributors of an AGP that is approved by the AA for an upcoming ANV.
+- 300 ANT to be split between any listed authors of an AGP that is approved by ANT voters.
+- 200 ANT to be split between any listed contributors of an AGP that is approved by ANT voters.
 
-200 ANT to any listed contributors of an AGP that is approved by the AA for an upcoming ANV.
+To receive authorship rewards AGP authors must include an Ethereum address which can receive the ANT ERC-20 token in the proposal. This can be added to the `Author` section in the header of the AGP. Names and addresses listed in the `Author` section of the header should be treated as authors or co-authors in regards to AGP authorship rewards.
 
-300 ANT to the author of an AGP that is approved by ANT voters.
+To receive contributor rewards AGP authors must also include a list of contributors and their Ethereum addresses. This can be added to the `Author` section in the header of the AGP, however, it must be specified that these are contributors and not main authors. All names and addresses in the `Author` section will be treated as co-authors unless otherwise marked as co-authors. If AGP authors do not list contributors in an AGP, then the contributor rewards will simply not be paid out. The AGP author will not be paid more.
 
-200 ANT to any listed contributors of an AGP that is approved by ANT voters.
+The following example shows what an AGP `Author` section with 2 co-authors and 2 contributors would look like:
+- Author: burrrata (@burrrata) 0xa328500Eab14b26C93AA6D1b25698b895F35f5Ee, not-burrrata (@not-burrrata) 0x01b25698b85b26C90Eab14a323AA6D895F35f5Ee, #contributor also-not-burrrata (@also-not-burrrata) 0x00Eab14a321b25698b85b26C93AA6D895F35f5Ee, #contributor definitely-not-burrrata (@definitely-not-burrrata) 0xa321b25698b8500Eab14b26C93AA6D895F35f5Ee
 
-## Number and frequency of transfers if recurring (enter “1” if only one payment will be made)
-1.
+ANT rewards will be split equally between all AGP authors. If a community member has contributed a lot they can be listed as a co-author and the authorship reward can be split between co-authors. Overall, this AGP aims to encourage collaboration by rewarding and recognizing community members who contribute to AGP conversations.
 
-## Purpose of the transfer
-Aragon is a decentralized governance platform. AGPs are the foundation of the governance process. Engaging in governance is hard. It takes lots of time, emotional energy, and time. There is currently no motivation to engage in AGP discussions or author AGPs other than altruism or personal interest. This greatly reduces the time and effort spent on AGPs.
+If an AGP author lists contributors, ANT rewards will be split equally between all contributors equally. While this does not account for the fact that some contributors will have done more work than others, it keeps things simple and is a major step forward from the current situation.
 
-To address this we need to reward AGP authors. They are doing the Aragon community a service by engaging in discussions, packing ideas into AGPs, receiving community feedback, modifying AGPs, and pushing them through the various stages of the ANV process. AGPs are one of the most important aspects of the Aragon community.
+In order to receive authorship or contributor rewards, authors and/or contributors must provide an Ethereum address where they wish to receive authorship or contributor ANT rewards.
 
-The following rewards seem like a healthy incentive to get more people's attention focused on AGPs, both in authorship and diligence:
-- 300 ANT to the author of an AGP that is approved by the AA for an upcoming ANV
-- 200 ANT to contributors of an AGP that is approved by the AA for an upcoming ANV
-- 300 ANT to the author of an AGP that is approved by ANT voters
-- 200 ANT to contributors of an AGP that is approved by ANT voters
+## Motivation for changing this Association policy
 
- Passing the community review and Aragon Association review periods disqualifies any completely spammy proposals. If a proposal makes it through both review periods it could be assumed that it is adding some value to the community. Passing in an Aragon Network Vote shows that ANT holders appreciate the proposal and want the value it creates. AGP authors and contributors do a lot of work to provide this value and they should be rewarded accordingly.
+Aragon is a decentralized governance platform. AGPs are the foundation of Aragon's governance process. Engaging in governance is hard. It takes lots of time, emotional energy, and time. There is currently no motivation to engage in AGP discussions or author AGPs other than altruism or personal interest. This greatly reduces the time and effort spent on AGPs.
 
-If AGP authors do not list contributors in an AGP, then the contributor rewards will simply not be paid out. The AGP author will not be paid more.
+To address this we need to reward AGP authors. They are doing the Aragon community a service by engaging in discussions, packaging ideas into AGPs, receiving community feedback on those AGPs, modifying AGPs based on that feedback, and then moving AGPs through the various stages of the ANV process. Again, this takes a lot of work and time, but it's important because AGPs are one of the most important aspects of the Aragon community.
 
-If an AGP author lists contributors, rewards will be split equally between all contributors equally. While this does not account for the fact that some contributors will have done more work than others, it keeps things simple and is a major step forward from the current situation.
-
-If a community member has contributed a lot they can be listed as a co-author and the authorship reward can be split between co-authors. Overall, this AGP aims to encourage collaboration by rewarding and recognizing community members who contribute to AGP conversations.
-
-In order to receive authorship or contributor rewards authors and/or contributors must add an Ethereum address to the AGP where they wish to receive authorship or contributor rewards.
-
-The Aragon Association will pay out AGP authorship and contributor rewards at the end of every ANV cycle after ANT votes have been finalized and announced.
-
-## Recipient information
-Future AGP authors and contributors.
+Passing the community review and Aragon Association review periods disqualifies any completely spammy proposals. If an AGP makes it through both review periods it could be assumed that it is adding some value to the community. If an AGP Passes in an Aragon Network Vote that clearly shows that ANT holders appreciate the proposal and want the value that it creates. AGP authors and contributors do a lot of work to provide this value to the Aragon network and they should be rewarded accordingly.
 
 ## License
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
-

--- a/AGPs/AGP-Authorship-Rewards-Program.md
+++ b/AGPs/AGP-Authorship-Rewards-Program.md
@@ -11,7 +11,7 @@ Created: 2019-10-02
 
 ## Description of desired Association policy change
 
-The Aragon Association will reward AGP authors and contributors with ANT at the end of every ANV cycle after ANT votes have been finalized and announced. The ANT rewards will be:
+The Aragon Association ("AA") will reward AGP authors and contributors with ANT at the end of every Aragon Network Vote ("ANV") cycle after ANT votes have been finalized and announced. The ANT rewards will be:
 - 300 ANT to be split between any listed authors of an AGP that is approved by the AA for an upcoming ANV.
 - 200 ANT to be split between any listed contributors of an AGP that is approved by the AA for an upcoming ANV.
 - 300 ANT to be split between any listed authors of an AGP that is approved by ANT voters.

--- a/AGPs/AGP-Authorship-Rewards-Program.md
+++ b/AGPs/AGP-Authorship-Rewards-Program.md
@@ -26,7 +26,7 @@ The following example shows what an AGP `Author` section with 2 co-authors and 2
 
 ANT rewards will be split equally between all AGP authors. If a community member has contributed a lot they can be listed as a co-author and the authorship reward can be split between co-authors. Overall, this AGP aims to encourage collaboration by rewarding and recognizing community members who contribute to AGP conversations.
 
-If an AGP author lists contributors, ANT rewards will be split equally between all contributors equally. While this does not account for the fact that some contributors will have done more work than others, it keeps things simple and is a major step forward from the current situation.
+If an AGP author lists contributors, ANT rewards will be split between all contributors equally. While this does not account for the fact that some contributors will have done more work than others, it keeps things simple and is a major step forward from the current situation.
 
 In order to receive authorship or contributor rewards, authors and/or contributors must provide an Ethereum address where they wish to receive authorship or contributor ANT rewards.
 

--- a/AGPs/AGP-Authorship-Rewards-Program.md
+++ b/AGPs/AGP-Authorship-Rewards-Program.md
@@ -17,7 +17,7 @@ The Aragon Association ("AA") will reward AGP authors and contributors with ANT 
 - 300 ANT to be split between any listed authors of an AGP that is approved by ANT voters.
 - 200 ANT to be split between any listed contributors of an AGP that is approved by ANT voters.
 
-To receive authorship rewards AGP authors must include an Ethereum address which can receive the ANT ERC-20 token in the proposal. This can be added to the `Author` section in the header of the AGP. Names and addresses listed in the `Author` section of the header should be treated as authors or co-authors in regards to AGP authorship rewards.
+To receive authorship rewards AGP authors must include an Ethereum address that can receive the ANT ERC-20 token in the proposal. This can be added to the `Author` section in the header of the AGP. Names and addresses listed in the `Author` section of the header should be treated as authors or co-authors in regards to AGP authorship rewards.
 
 To receive contributor rewards AGP authors must also include a list of contributors and their Ethereum addresses. This can be added to the `Author` section in the header of the AGP, however, it must be specified that these are contributors and not main authors. All names and addresses in the `Author` section will be treated as co-authors unless otherwise marked as co-authors. If AGP authors do not list contributors in an AGP, then the contributor rewards will simply not be paid out. The AGP author will not be paid more.
 

--- a/AGPs/AGP-Authorship-Rewards-Program.md
+++ b/AGPs/AGP-Authorship-Rewards-Program.md
@@ -36,7 +36,7 @@ Aragon is a decentralized governance platform. AGPs are the foundation of Aragon
 
 To address this we need to reward AGP authors. They are doing the Aragon community a service by engaging in discussions, packaging ideas into AGPs, receiving community feedback on those AGPs, modifying AGPs based on that feedback, and then moving AGPs through the various stages of the ANV process. Again, this takes a lot of work and time, but it's important because AGPs are one of the most important aspects of the Aragon community.
 
-Passing the community review and Aragon Association review periods disqualifies any completely spammy proposals. If an AGP makes it through both review periods it could be assumed that it is adding some value to the community. If an AGP Passes in an Aragon Network Vote that clearly shows that ANT holders appreciate the proposal and want the value that it creates. AGP authors and contributors do a lot of work to provide this value to the Aragon network and they should be rewarded accordingly.
+Passing the community review and Aragon Association review periods disqualifies any completely spammy proposals. If an AGP makes it through both review periods it could be assumed that it is adding some value to the community. If an AGP is approved in an Aragon Network Vote that clearly shows that ANT holders appreciate the proposal and want the value that it creates. AGP authors and contributors do a lot of work to provide this value to the Aragon network and they should be rewarded accordingly.
 
 ## License
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
[Old PR for this AGP](https://github.com/aragon/AGPs/pull/100) broke due to technical difficulties.

Was told by AGP Editor @john-light to resubmit AGP PR in [this](https://forum.aragon.org/t/call-for-an-emergency-vote-to-push-back-every-stage-of-anv4-by-1-week/1356/26) forum comment.

This AGP is set for the Finance track because [AGP-1](https://github.com/aragon/AGPs/blob/master/AGPs/AGP-1.md) recommend this for AGPs that affect the movement of assets held by the Association multisig. That being said, some of the fields in the Finance track template were not quite a good fit for this AGP. Ex: Address of the transfer recipient and Recipient information are not specified beyond "future AGP authors and contributors." 

@john-light @lkngtn
- Is this AGP a good fit for the Finance track?
- Would this AGP be better for another track such as Meta in order to add author and contributor addresses as a field to the AGP track templates? If so, can Meta track proposals also specify the movement of funds (such as rewarding AGP authors and contributors with ANT)? 